### PR TITLE
Do NOT reformat comment when comment contains xml elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+*.chk
+*.jrs
+*.ide

--- a/TestAttributeSortingOptionHandling.xaml
+++ b/TestAttributeSortingOptionHandling.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="MainWindow"
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"

--- a/TestAttributeSortingOptionHandling.xaml
+++ b/TestAttributeSortingOptionHandling.xaml
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<Window x:Class="MainWindow"
+﻿<Window x:Class="MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="WPF3D"

--- a/TestCommentHandling.xaml
+++ b/TestCommentHandling.xaml
@@ -16,6 +16,24 @@
         second line
     -->
 
+    <!--  Do not reformat commented xml tags -->
+	<!--<DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />-->
+	    <!--
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />
+ -->
+
     <!--  END: Test for COMMENT hanlding  -->
 
 </Root>

--- a/TestCommentHandling_output_expected.xaml
+++ b/TestCommentHandling_output_expected.xaml
@@ -16,6 +16,24 @@
     second line
   -->
 
+  <!--  Do not reformat commented xml tags  -->
+  <!--<DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />-->
+  <!--
+        <DataPager PageSource="{Binding .}" PageIndex="3" />
+
+        <Button Margin="0,0,0,10"
+                Content="&#xE112;"
+                FontFamily="Segoe UI Symbol"
+                FontSize="18.667"
+                Padding="8,8,0,0" />
+  -->
+
   <!--  END: Test for COMMENT hanlding  -->
 
 </Root>

--- a/XamlStyler.Package/ReleaseNotes.txt
+++ b/XamlStyler.Package/ReleaseNotes.txt
@@ -1,4 +1,10 @@
-﻿1.3.6
+﻿1.3.7
+-----
+Added Xamarin support
+Fix for Content of element is changed when using encoded unicode (Thanks Philip Hoppe!)
+
+
+1.3.6
 -----
 Fixed empty line in Grid bug
 

--- a/XamlStyler.Package/StylerPackage.cs
+++ b/XamlStyler.Package/StylerPackage.cs
@@ -105,7 +105,16 @@ namespace NicoVermeir.XamlStyler_Package
 
         private bool IsFormatableDocument(Document document)
         {
-            return !document.ReadOnly && document.Language == "XAML";
+            bool isFormatableDocument;
+            isFormatableDocument = !document.ReadOnly && document.Language == "XAML";
+
+            if (!isFormatableDocument)
+            {
+                //xamarin
+                isFormatableDocument = document.Language == "XML" && document.FullName.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return isFormatableDocument;
         }
 
         private void OnFileSaveSelectedItemsBeforeExecute(string guid, int id, object customIn, object customOut,

--- a/XamlStyler.Package/source.extension.vsixmanifest
+++ b/XamlStyler.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="a224be3c-88d1-4a57-9804-181dbef68021" Version="1.3.6" Language="en-US" Publisher="Nico Vermeir" />
+    <Identity Id="a224be3c-88d1-4a57-9804-181dbef68021" Version="1.3.7" Language="en-US" Publisher="Nico Vermeir" />
     <DisplayName>XAML Styler</DisplayName>
     <Description xml:space="preserve">"XAML Styler" is a visual studio extension, which makes XAML markup source code beautify much easier by sorting the attributes based on their importance.
 This tool can help you/your team maintain a better XAML coding style as well as a much better XAML readability.
@@ -13,7 +13,7 @@ This is a continuation of the original XAML styler found at http://xamlstyler.co
     <GettingStartedGuide>https://github.com/NicoVermeir/XamlStyler/</GettingStartedGuide>
     <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
     <Icon>Resources\Package.ico</Icon>
-    <Tags>XAML, add-in, WPF, Visual Studio, Extension, formatter, Silverlight, WP8, WinRT</Tags>
+    <Tags>XAML, add-in, WPF, Visual Studio, Extension, formatter, Silverlight, WP8, WinRT, Xamarin</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
     <InstallationTarget Version="[12.0,13.0)" Id="Microsoft.VisualStudio.Pro" />

--- a/XamlStyler.Service/Helpers/StringExtension.cs
+++ b/XamlStyler.Service/Helpers/StringExtension.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace XamlStyler.Core.Helpers
 {
@@ -19,6 +21,18 @@ namespace XamlStyler.Core.Helpers
             }
 
             return buffer.ToString();
+        }
+
+        public static IEnumerable<string> GetLines(this string source)
+        {
+            using (var reader = new StringReader(source))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    yield return line;
+                }
+            }
         }
     }
 }

--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -398,27 +398,41 @@ namespace XamlStyler.Core
         private void ProcessComment(XmlReader xmlReader, ref string output)
         {
             string currentIndentString = GetIndentString(xmlReader.Depth);
-            string content = xmlReader.Value.Trim();
+            string content = xmlReader.Value;
 
             if (!output.EndsWith("\n"))
             {
                 output += Environment.NewLine;
             }
 
-            if (content.Contains("\n"))
+            if (content.Contains("<") && content.Contains(">"))
+            {
+                output += currentIndentString + "<!--";
+                if (content.Contains("\n"))
+                {
+                    output += string.Join(Environment.NewLine, content.GetLines().Select(x=>x.TrimEnd(' ')));
+                    if (content.TrimEnd(' ').EndsWith("\n"))
+                    {
+                        output += currentIndentString;
+                    }
+                }
+                else
+                    output += content;
+
+                output += "-->";
+            }
+            else if (content.Contains("\n"))
             {
                 output += currentIndentString + "<!--";
 
                 string contentIndentString = GetIndentString(xmlReader.Depth + 1);
-                string[] lines = content.Split('\n');
-
-                output = lines.Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
+                output = content.Trim().GetLines().Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
 
                 output += Environment.NewLine + currentIndentString + "-->";
             }
             else
             {
-                output += currentIndentString + "<!--  " + content + "  -->";
+                output += currentIndentString + "<!--  " + content.Trim() + "  -->";
             }
         }
 

--- a/XamlStyler.Service/StylerService.cs
+++ b/XamlStyler.Service/StylerService.cs
@@ -409,27 +409,41 @@ namespace XamlStyler.Core
         private void ProcessComment(XmlReader xmlReader, ref string output)
         {
             string currentIndentString = GetIndentString(xmlReader.Depth);
-            string content = xmlReader.Value.Trim();
+            string content = xmlReader.Value;
 
             if (!output.EndsWith("\n"))
             {
                 output += Environment.NewLine;
             }
 
-            if (content.Contains("\n"))
+            if (content.Contains("<") && content.Contains(">"))
+            {
+                output += currentIndentString + "<!--";
+                if (content.Contains("\n"))
+                {
+                    output += string.Join(Environment.NewLine, content.GetLines().Select(x=>x.TrimEnd(' ')));
+                    if (content.TrimEnd(' ').EndsWith("\n"))
+                    {
+                        output += currentIndentString;
+                    }
+                }
+                else
+                    output += content;
+
+                output += "-->";
+            }
+            else if (content.Contains("\n"))
             {
                 output += currentIndentString + "<!--";
 
                 string contentIndentString = GetIndentString(xmlReader.Depth + 1);
-                string[] lines = content.Split('\n');
-
-                output = lines.Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
+                output = content.Trim().GetLines().Aggregate(output, (current, line) => current + (Environment.NewLine + contentIndentString + line.Trim()));
 
                 output += Environment.NewLine + currentIndentString + "-->";
             }
             else
             {
-                output += currentIndentString + "<!--  " + content + "  -->";
+                output += currentIndentString + "<!--  " + content.Trim() + "  -->";
             }
         }
 


### PR DESCRIPTION
This is to handle when you place a comment around a section of XAML, that you later expect to incorporate again.
In that case it is counterproductive to reformat comment. Just leave it as is.

Also handle mixed line endings correctly (DOS versus Unix line endings)
